### PR TITLE
Fix wrongly referenced id in action on ts0044 blueprint

### DIFF
--- a/blueprints/ts0044_zigbee_remote.yaml
+++ b/blueprints/ts0044_zigbee_remote.yaml
@@ -193,7 +193,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - b1-1
+              - b2-1
         sequence: !input button_2_press
       - conditions:
           - condition: trigger


### PR DESCRIPTION
After importing your blueprint I have found a small issue with the second button that didn't work on short press. It is because the wrong trigger is referenced so I fixed it.